### PR TITLE
CO-108 co-questionssearch

### DIFF
--- a/web/src/main/java/ru/atott/combiq/web/controller/SearchController.java
+++ b/web/src/main/java/ru/atott/combiq/web/controller/SearchController.java
@@ -40,7 +40,17 @@ public class SearchController extends BaseController {
         SearchContext context = searchQuestionContextFactory.listByDsl(page, dsl);
         return getView(request, context, dsl);
     }
-
+    @ResponseBody
+    @RequestMapping(value = "/questions/search/json", method = RequestMethod.GET)
+    public Object searchTop10(HttpServletRequest request,
+                               @RequestParam(defaultValue = "1") int page,
+                               @RequestParam(defaultValue = "10") int size,
+                               @RequestParam(value = "q", defaultValue = "") String dsl) {
+        page = getZeroBasedPage(page);
+        SearchContext context = searchQuestionContextFactory.listBySizeAndDsl(page, size, dsl);
+        SearchResponse questionsResponse = searchService.searchQuestions(context);
+        return questionsResponse.getQuestions();
+    }
     @ResponseBody
     @RequestMapping(value = "/questions/search/count", method = RequestMethod.GET)
     public Object countSearch(HttpServletRequest request,

--- a/web/src/main/java/ru/atott/combiq/web/utils/SearchQuestionContextFactory.java
+++ b/web/src/main/java/ru/atott/combiq/web/utils/SearchQuestionContextFactory.java
@@ -65,6 +65,17 @@ public class SearchQuestionContextFactory {
         context.setUserId(authService.getUserId());
         return context;
     }
+    public SearchContext listBySizeAndDsl(int page, int size, String dsl) {
+        DslQuery dslQuery = DslParser.parse(dsl);
+
+        SearchContext context = new SearchContext();
+        context.setUserContext(authService.getUserContext());
+        context.setFrom(page * size);
+        context.setSize(size);
+        context.setDslQuery(dslQuery);
+        context.setUserId(authService.getUserId());
+        return context;
+    }
 
     public SearchContext listByDeleted(int page, boolean deleted) {
         DslQuery query = new DslQuery();

--- a/web/src/main/webapp/WEB-INF/view/user/user-common.ftl
+++ b/web/src/main/webapp/WEB-INF/view/user/user-common.ftl
@@ -7,8 +7,10 @@
     <#assign head>
         <link rel="stylesheet" href="/static/css/user.css?v=${resourceVersion}">
     </#assign>
-
-    <@templates.layoutWithoutSidebar head=head>
+    <#assign sidebar>
+        <co-questionssearch params="title: 'Добавленные в избранное', dsl: 'favorite:true'"></co-questionssearch>
+    </#assign>
+    <@templates.layoutWithSidebar head=head sidebar=sidebar>
 
         <div class="co-userpage">
 
@@ -22,5 +24,6 @@
                 <#nested />
             </div>
         </div>
-    </@templates.layoutWithoutSidebar>
+    </@templates.layoutWithSidebar>
+
 </#macro>

--- a/web/src/main/webapp/static/css/styles.css
+++ b/web/src/main/webapp/static/css/styles.css
@@ -839,11 +839,11 @@ ul.co-component-question-tags > li {
 }
 
 .co-component-question-level-bound {
-      width: 10%;
+    width: 60px;
 }
 
 .co-component-question-content {
-      width: 90%;
+    width: 90%;
 }
 
 .co-level {

--- a/web/src/main/webapp/static/ko_components/co-questionssearch/co-questionssearch.css
+++ b/web/src/main/webapp/static/ko_components/co-questionssearch/co-questionssearch.css
@@ -1,0 +1,27 @@
+.co-questionsearch-content {
+    z-index: 5;
+    position:relative;
+    width: 100%;
+    height: 100%;
+    min-height: 100px;
+}
+.co-questionsearch-preloader{
+    margin:auto;
+    position: absolute;
+    left:50%;
+    margin-left:-32px;
+    top: 50%;
+    margin-top: -32px;
+}
+.co-questionsearch-all{
+    margin-top: -20px;
+}
+.co-questionsearch-comment{
+    margin-left: 10px;
+    font-size: 13px;
+    display: table;
+    color: #007fb6
+}
+.co-questionsearch-comment-count{
+    margin-left: 3px
+}

--- a/web/src/main/webapp/static/ko_components/co-questionssearch/co-questionssearch.html
+++ b/web/src/main/webapp/static/ko_components/co-questionssearch/co-questionssearch.html
@@ -1,0 +1,44 @@
+<div data-bind = "init: init">
+    <h4 data-bind="text: title"></h4>
+    <div   class="co-questionsearch-content">
+        <div  class = "co-questionsearch-preloader" data-bind="element: preloader" >
+            <img src="/static/images/site/preloader.gif"/>
+        </div>
+        <span data-bind="html: sizeDescr"/>
+        <ul data-bind="template: { name: 'co-question-template', foreach: questions }" class="co-questions"/>
+        <div class="co-questionsearch-all" data-bind="html: findAll"/>
+    </div>
+</div>
+
+<script type="text/html" id="co-question-template">
+    <li>
+        <div class="co-component-question">
+            <div class="co-component-question-level-bound">
+                <div class="co-component-question-level">
+                    <div data-bind="css: 'co-level-'+level.toLowerCase()" class="co-level">
+                        <span data-bind="text: level"></span>
+                    </div>
+                    <div class="co-component-question-level-desc">уровень</div>
+                </div>
+            </div>
+            <div class="co-component-question-content">
+                <div class="co-component-question-text">
+                    <span data-bind="text: title"></span>
+                </div>
+                <div>
+                    <ul class="co-component-question-tags" data-bind="foreach: { data: tags, as: 'tag' }">
+                        <li>
+                            <div class="co-tag">
+                                <span data-bind="text: tag"></span>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div data-bind="if: comments.length > 0" class="co-questionsearch-comment">
+                <span class="glyphicon glyphicon-comment"/>
+                <span class="co-questionsearch-comment-count" data-bind="text: comments.length"/>
+            </div>
+        </div>
+    </li>
+</script>

--- a/web/src/main/webapp/static/ko_components/co-questionssearch/co-questionssearch.js
+++ b/web/src/main/webapp/static/ko_components/co-questionssearch/co-questionssearch.js
@@ -1,0 +1,35 @@
+define(['knockout', 'ajax'], function(ko, ajax) {
+    function ViewModel(params) {
+        this.title = ko.wrap(params.title)
+        this.preloader = ko.wrap();
+        this.sizeDescr = ko.wrap();
+        this.questions = ko.wrap();
+        this.findAll = ko.wrap();
+        this.size = params.size != undefined ? params.size : '';
+        this.dsl = params.dsl !== undefined ? params.dsl : '';
+    };
+    ViewModel.prototype.init = function() {
+        var self = this;
+        $.get('/questions/search/json',
+                {
+                    q: self.dsl,
+                    size: self.size
+                },
+                function(data) {
+                    self.preloader().hide();
+                    var totalSize = data.totalElements;
+                    var size = self.size.length > 0 ? self.size : 10;
+                    size = size < totalSize ? size : totalSize;
+                    self.sizeDescr('Первые ' + size + ' из ' +
+                                        '<a title="Искать все вопросы" href="/questions/search'+
+                                        (self.dsl.length > 0 ? '?q='+self.dsl : '') +
+                                        '">'+ totalSize +'</a>' +
+                                        ' вопросов');
+                    self.findAll("<a href = '/questions/search"+
+                                                (self.dsl.length > 0 ? "?q="+self.dsl : "")
+                                                +"'>Искать все вопросы</a>");
+                    self.questions(data.content);
+                });
+    };
+    return ViewModel;
+});

--- a/web/src/main/webapp/static/ko_components/components.js
+++ b/web/src/main/webapp/static/ko_components/components.js
@@ -36,6 +36,7 @@
     define('co-posteditor', 'ko_components/co-posteditor', 'co-posteditor', {layoutSeparated: true, styles: 'css'});
     define('co-onlywithcomments', 'ko_components/co-onlywithcomments', 'co-onlywithcomments', {layoutSeparated: true});
     define('co-star', 'ko_components/co-star', 'co-star', {layoutSeparated: true, styles: 'css'});
+    define('co-questionssearch', 'ko_components/co-questionssearch', 'co-questionssearch', {layoutSeparated: true, styles: 'css'});
 
     ko.createComponent = function(componentName, params, tag) {
         var html;


### PR DESCRIPTION
Компонент co-questionssearch (выводит список вопросов по заданному DLS)

Параметры компонента:
 - dsl, например "favorite:true"
 - title заголовок к списку
 - size количество вопросов для отображения (по умолчанию 10)

Компонент при инициализации делает запрос на сервер за вопросами по этому DLS и отображает первые valueOf(size) вопросов
Во время загрузки отображается прелоадер (крутилку)
Отображается количество найденных вопросов, а так-же общее количество вопросов по заданному DLS
Есть ссылка, которая редиректит на страницу основного поиска с таким DLS

Пример использования есть в личном кабинете.